### PR TITLE
Limit presence of Import link to user-owned characters

### DIFF
--- a/pathbuilder-import.js
+++ b/pathbuilder-import.js
@@ -1,6 +1,9 @@
 // its a single page as I've been testing it in macros.
 
 Hooks.on('renderActorSheet', function(obj, html){
+    // Only inject the link if the actor is of type "character" and the user has permission to update it
+    const actor = obj.actor;
+    if (!(actor.data.type === "character" && actor.can(game.user, "update"))) return;
 
     let element = html.find(".window-header .window-title");
     if (element.length != 1) return;


### PR DESCRIPTION
This will prevent the "Import from Pathbuilder 2e" link from showing on, e.g., NPCs, as well as PCs the user doesn't have permission to update.